### PR TITLE
Empty start value won't let you come here

### DIFF
--- a/manuscript/developing_with_webpack/automatic_browser_refresh.md
+++ b/manuscript/developing_with_webpack/automatic_browser_refresh.md
@@ -72,7 +72,7 @@ leanpub-end-insert
 
 ...
 
-if(TARGET === 'start' || !TARGET) {
+if(TARGET === 'start') {
 leanpub-start-delete
   module.exports = merge(common, {});
 leanpub-end-delete
@@ -130,7 +130,7 @@ The setup may be problematic on certain versions of Windows and Ubuntu. Instead 
 ```javascript
 ...
 
-if(TARGET === 'start' || !TARGET) {
+if(TARGET === 'start') {
   module.exports = merge(common, {});
 }
 


### PR DESCRIPTION
Found this small mistake while reading this perfect webpack intro book.
If `start` is empty, `npm run ***` won't execute `webpack` and the work flow won't come here.