### PR TITLE
Fixes a small typo and adds context for code snippet on 'Configuring React' page

### DIFF
--- a/manuscript/advanced_techniques/05_configuring_react.md
+++ b/manuscript/advanced_techniques/05_configuring_react.md
@@ -6,7 +6,7 @@ Babel is useful beyond React development and worth understanding as it allows yo
 
 ## Setting Up Babel with React
 
-Most of the React code out there relies on a format known as [JSX](https://facebook.github.io/jsx/). It is a superset of JavaScript that allows you to mix XMLis syntax with JavaScript.
+Most of the React code out there relies on a format known as [JSX](https://facebook.github.io/jsx/). It is a superset of JavaScript that allows you to mix XML syntax with JavaScript.
 
 A lot of people find this convenient as they get something that resembles what they know already while they can use the power of JavaScript. This is in contrast to template DSLs that implement the same logic using custom constructs.
 

--- a/manuscript/advanced_techniques/05_configuring_react.md
+++ b/manuscript/advanced_techniques/05_configuring_react.md
@@ -36,11 +36,14 @@ Webpack provides a field known as [resolve.extensions](https://webpack.github.io
 
 ```javascript
 ...
-// Important! Do not remove ''. If you do, imports without
-// an extension won't work anymore!
-resolve: {
-  extensions: ['', '.js', '.jsx']
-},
+const common = {
+  ...
+  // Important! Do not remove ''. If you do, imports without
+  // an extension won't work anymore!
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  }
+}
 ...
 ```
 


### PR DESCRIPTION
Fixes a small typo and adds context to the code snippet for `resolve.extensions` on the 'Configuring React' page.