### PR TITLE
Improve poll watching with watchIgnorePlugin

### DIFF
--- a/manuscript/developing_with_webpack/03_automatic_browser_refresh.md
+++ b/manuscript/developing_with_webpack/03_automatic_browser_refresh.md
@@ -173,15 +173,15 @@ const webpack = require('webpack');
 
 exports.devServer = function(options) {
   return {
-leanpub-start-insert
-    watchOptions: {
-      // Delay the rebuild after the first change
-      aggregateTimeout: 300,
-      // Poll using interval (in ms, accepts boolean too)
-      poll: 1000
-    },
-leanpub-end-insert
     devServer: {
+leanpub-start-insert
+      watchOptions: {
+        // Delay the rebuild after the first change
+        aggregateTimeout: 300,
+        // Poll using interval (in ms, accepts boolean too)
+        poll: 1000
+      },
+leanpub-end-insert
       ...
     },
     ...

--- a/manuscript/developing_with_webpack/03_automatic_browser_refresh.md
+++ b/manuscript/developing_with_webpack/03_automatic_browser_refresh.md
@@ -184,7 +184,15 @@ leanpub-start-insert
 leanpub-end-insert
       ...
     },
-    ...
+    plugins: [
+leanpub-start-insert
+      // ignore node_modules so CPU usage with poll watching drops significantly
+      new webpack.WatchIgnorePlugin([
+        path.join(__dirname, 'node_modules')
+      ]),
+leanpub-end-insert
+      ...
+    ]
   };
 }
 ```


### PR DESCRIPTION
I am sure many people will use Vagrant boxes even more than now so I thought this would be nice to add. 

The problem with polling is that it polls EVERYTHING by default. CPU usage is close to 100% on guest machine when polling and doing nothing else. Webpack has watchIgnorePlugin built in it and by using it to ignore node_modules folder (optionally other folders) the cpu usage is around 10%.

Tell me if you have comments on my PR :)