### PR TITLE
Add node_modules to ESLint ignore

### DIFF
--- a/manuscript/developing_with_webpack/05_linting.md
+++ b/manuscript/developing_with_webpack/05_linting.md
@@ -117,11 +117,12 @@ module.exports = {
 };
 ```
 
-In addition we need to tell ESLint to skip linting possible *build* directory by setting up ignore patterns:
+In addition we need to tell ESLint to skip linting *node_modules* and *build* directories by setting up ignore patterns:
 
 **.eslintignore**
 
 ```bash
+node_modules/
 build/
 ```
 


### PR DESCRIPTION
It lints everything by default.