### PR TITLE
add args to loadCSS call

### DIFF
--- a/manuscript/handling_styles/01_loading.md
+++ b/manuscript/handling_styles/01_loading.md
@@ -61,7 +61,7 @@ module.exports = function(env) {
       ],
     },
 leanpub-start-insert
-    parts.loadCSS(),
+    parts.loadCSS([PATHS.app]),
 leanpub-end-insert
     parts.devServer({
       // Customize host/port here if needed


### PR DESCRIPTION
function gets undefined for the `include` rule, code works anyway so I suppose the default is to include all files ?