### PR TITLE
optimizing - fix grammar

### DIFF
--- a/manuscript/optimizing_build/01_minifying.md
+++ b/manuscript/optimizing_build/01_minifying.md
@@ -144,7 +144,7 @@ leanpub-start-insert
 };
 
 const treeShakingDemo = function () {
-  return 'this should get shaked out';
+  return 'this should get shaken out';
 };
 
 export {


### PR DESCRIPTION
Correct use of past participle of 'shake' from 'shaked' to 'shaken'.