### PR TITLE
Optimising Build - Wrong filename for code block

### DIFF
--- a/manuscript/optimizing_build/03_adding_hashes_to_filenames.md
+++ b/manuscript/optimizing_build/03_adding_hashes_to_filenames.md
@@ -77,7 +77,7 @@ To make the extracted CSS pick up a hash, we should set `contenthash` for it. We
 
 This means a change made to the application code would invalidate CSS hash as well or vice versa. Instead, relying on a hash generated based on the CSS content is a stable way to go.
 
-**webpack.config.js**
+**webpack.parts.js**
 
 ```javascript
 ...


### PR DESCRIPTION
Filename was webpack.config.js but the code below comes from webpack.parts.js.